### PR TITLE
allow ability to omit fields from being tracked in history

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ const useStoreWithUndo = create<StoreState>(
 ## Omit fields from being tracked in history
 
 Some fields you may not want to track in history and they can be ignored by zundo middleware.
-The second parameter for `undoMiddleware` is a string of keys on `StoreState` to be omitted from being tracked in history.
+The second `options` parameter for `undoMiddleware` contains an `omit` field which is an array of string of keys on `StoreState` to be omitted from being tracked in history.
 
 ```tsx
 const useStore = create<StoreState>(
   undoMiddleware(
     set => ({ ... }),
-    ['field1', 'field2']
+    { omit: ['field1', 'field2'] }
   )
 );
 ```

--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ const useStoreWithUndo = create<StoreState>(
 );
 ```
 
+### Other features
+
+## Omit fields from being tracked in history
+
+Some fields you may not want to track in history and they can be ignored by zundo middleware.
+The second parameter for `undoMiddleware` is a string of keys on `StoreState` to be omitted from being tracked in history.
+
+```tsx
+const useStore = create<StoreState>(
+  undoMiddleware(
+    set => ({ ... }),
+    ['field1', 'field2']
+  )
+);
+```
+
 ## API
 
 ### `undoMiddleware(config: StateCreator<TState>)`

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -14,7 +14,7 @@ export interface UndoStoreState {
   setStore: Function;
   // handle on the parent store's getter
   getStore: Function;
-  options: Options;
+  options?: Options;
 }
 
 // factory to create undoStore. contains memory about past and future states and has methods to traverse states
@@ -24,29 +24,17 @@ export const createUndoStore = () => {
       prevStates: [],
       futureStates: [],
       undo: () => {
-        const {
-          prevStates,
-          futureStates,
-          setStore,
-          getStore,
-          options: { omit = [] },
-        } = get();
+        const { prevStates, futureStates, setStore, getStore, options } = get();
         if (prevStates.length > 0) {
-          futureStates.push(filterState(getStore(), omit));
+          futureStates.push(filterState(getStore(), options?.omit || []));
           const prevState = prevStates.pop();
           setStore(prevState);
         }
       },
       redo: () => {
-        const {
-          prevStates,
-          futureStates,
-          setStore,
-          getStore,
-          options: { omit = [] },
-        } = get();
+        const { prevStates, futureStates, setStore, getStore, options } = get();
         if (futureStates.length > 0) {
-          prevStates.push(filterState(getStore(), omit));
+          prevStates.push(filterState(getStore(), options?.omit || []));
           const futureState = futureStates.pop();
           setStore(futureState);
         }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,4 +1,5 @@
 import createVanilla from 'zustand/vanilla';
+import { filterState } from './utils';
 
 // use immer patches? https://immerjs.github.io/immer/patches/
 
@@ -12,6 +13,8 @@ export interface UndoStoreState {
   setStore: Function;
   // handle on the parent store's getter
   getStore: Function;
+  // TODO: make this a better type
+  ignored: string[];
 }
 
 // factory to create undoStore. contains memory about past and future states and has methods to traverse states
@@ -21,17 +24,17 @@ export const createUndoStore = () => {
       prevStates: [],
       futureStates: [],
       undo: () => {
-        const { prevStates, futureStates, setStore, getStore } = get();
+        const { prevStates, futureStates, setStore, getStore, ignored } = get();
         if (prevStates.length > 0) {
-          futureStates.push(getStore());
+          futureStates.push(filterState(getStore(), ignored));
           const prevState = prevStates.pop();
           setStore(prevState);
         }
       },
       redo: () => {
-        const { prevStates, futureStates, setStore, getStore } = get();
+        const { prevStates, futureStates, setStore, getStore, ignored } = get();
         if (futureStates.length > 0) {
-          prevStates.push(getStore());
+          prevStates.push(filterState(getStore(), ignored));
           const futureState = futureStates.pop();
           setStore(futureState);
         }
@@ -41,6 +44,7 @@ export const createUndoStore = () => {
       },
       setStore: () => {},
       getStore: () => {},
+      ignored: [],
     };
   });
 };

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,4 +1,5 @@
 import createVanilla from 'zustand/vanilla';
+import { Options } from './middleware';
 import { filterState } from './utils';
 
 // use immer patches? https://immerjs.github.io/immer/patches/
@@ -13,8 +14,7 @@ export interface UndoStoreState {
   setStore: Function;
   // handle on the parent store's getter
   getStore: Function;
-  // TODO: make this a better type
-  ignored: string[];
+  options: Options;
 }
 
 // factory to create undoStore. contains memory about past and future states and has methods to traverse states
@@ -24,17 +24,29 @@ export const createUndoStore = () => {
       prevStates: [],
       futureStates: [],
       undo: () => {
-        const { prevStates, futureStates, setStore, getStore, ignored } = get();
+        const {
+          prevStates,
+          futureStates,
+          setStore,
+          getStore,
+          options: { omit = [] },
+        } = get();
         if (prevStates.length > 0) {
-          futureStates.push(filterState(getStore(), ignored));
+          futureStates.push(filterState(getStore(), omit));
           const prevState = prevStates.pop();
           setStore(prevState);
         }
       },
       redo: () => {
-        const { prevStates, futureStates, setStore, getStore, ignored } = get();
+        const {
+          prevStates,
+          futureStates,
+          setStore,
+          getStore,
+          options: { omit = [] },
+        } = get();
         if (futureStates.length > 0) {
-          prevStates.push(filterState(getStore(), ignored));
+          prevStates.push(filterState(getStore(), omit));
           const futureState = futureStates.pop();
           setStore(futureState);
         }
@@ -44,7 +56,7 @@ export const createUndoStore = () => {
       },
       setStore: () => {},
       getStore: () => {},
-      ignored: [],
+      options: {},
     };
   });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,11 @@
 export { UndoState, undoMiddleware } from './middleware';
-export { UseStore } from "zustand";
+export { UseStore } from 'zustand';
 
 import createStore, { State, StateCreator } from 'zustand';
 import undoMiddleware from './middleware';
 
 // create a store with undo/redo functionality
-export const create = <TState extends State>(
-  config: StateCreator<TState>
-) => createStore<TState>(undoMiddleware(config));
+export const create = <TState extends State>(config: StateCreator<TState>) =>
+  createStore<TState>(undoMiddleware(config));
 
 export default create;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,11 +8,15 @@ export type UndoState = Partial<
   }
 >;
 
+export interface Options {
+  // TODO: improve this type. ignored should only be fields on TState
+  omit?: string[];
+}
+
 // custom zustand middleware to get previous state
 export const undoMiddleware = <TState extends UndoState>(
   config: StateCreator<TState>,
-  // TODO: improve this type. ignored should only be fields on TState
-  ignored: string[] = []
+  options: Options
 ) => (set: SetState<TState>, get: GetState<TState>, api: StoreApi<TState>) => {
   const undoStore = createUndoStore();
   const { getState, setState } = undoStore;
@@ -21,12 +25,12 @@ export const undoMiddleware = <TState extends UndoState>(
       setState({
         prevStates: [
           ...getState().prevStates,
-          filterState({ ...get() }, ignored),
+          filterState({ ...get() }, options.omit || []),
         ],
         setStore: set,
         futureStates: [],
         getStore: get,
-        ignored,
+        options,
       });
       /* TODO: const, should call this function and inject the values once, but it does
         it on every action call currently. */

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,7 +16,7 @@ export interface Options {
 // custom zustand middleware to get previous state
 export const undoMiddleware = <TState extends UndoState>(
   config: StateCreator<TState>,
-  options: Options
+  options?: Options
 ) => (set: SetState<TState>, get: GetState<TState>, api: StoreApi<TState>) => {
   const undoStore = createUndoStore();
   const { getState, setState } = undoStore;
@@ -25,7 +25,7 @@ export const undoMiddleware = <TState extends UndoState>(
       setState({
         prevStates: [
           ...getState().prevStates,
-          filterState({ ...get() }, options.omit || []),
+          filterState({ ...get() }, options?.omit || []),
         ],
         setStore: set,
         futureStates: [],

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 import { GetState, SetState, StateCreator, StoreApi } from 'zustand/vanilla';
 import { createUndoStore, UndoStoreState } from './factory';
+import { filterState } from './utils';
 
 export type UndoState = Partial<
   Pick<UndoStoreState, 'undo' | 'redo' | 'clear'> & {
@@ -9,21 +10,29 @@ export type UndoState = Partial<
 
 // custom zustand middleware to get previous state
 export const undoMiddleware = <TState extends UndoState>(
-  config: StateCreator<TState>
+  config: StateCreator<TState>,
+  // TODO: improve this type. ignored should only be fields on TState
+  ignored: string[] = []
 ) => (set: SetState<TState>, get: GetState<TState>, api: StoreApi<TState>) => {
   const undoStore = createUndoStore();
   const { getState, setState } = undoStore;
   return config(
     args => {
       setState({
-        prevStates: [...getState().prevStates, { ...get() }],
+        prevStates: [
+          ...getState().prevStates,
+          filterState({ ...get() }, ignored),
+        ],
         setStore: set,
         futureStates: [],
         getStore: get,
+        ignored,
       });
-      // TODO: const, should call this function and inject the values once, but it does
-      //   it on every action call currently.
+      /* TODO: const, should call this function and inject the values once, but it does
+        it on every action call currently. */
       const { undo, clear, redo } = getState();
+
+      // inject helper functions to user defined store.
       set({
         undo,
         clear,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,10 @@
+// TODO: make this a better type
+export const filterState = (state: any, ignored: string[]) => {
+  const filteredState: any = {};
+  Object.keys(state).forEach((key: string) => {
+    if (!ignored.includes(key)) {
+      filteredState[key] = state[key];
+    }
+  });
+  return filteredState;
+};

--- a/stories/bears.stories.tsx
+++ b/stories/bears.stories.tsx
@@ -39,7 +39,7 @@ const useStore = create<StoreState>(
         set(state => ({ bears: state.bears - 1, ignored: state.ignored - 1 })),
       removeAllBears: () => set({ bears: 0 }),
     }),
-    ['ignored']
+    { omit: ['ignored'] }
   )
 );
 

--- a/stories/bears.stories.tsx
+++ b/stories/bears.stories.tsx
@@ -21,6 +21,7 @@ export default meta;
 
 interface StoreState extends UndoState {
   bears: number;
+  ignored: number;
   increasePopulation: () => void;
   removeAllBears: () => void;
   decreasePopulation: () => void;
@@ -28,18 +29,25 @@ interface StoreState extends UndoState {
 
 // create a store with undo middleware
 const useStore = create<StoreState>(
-  undoMiddleware(set => ({
-    bears: 0,
-    increasePopulation: () => set(state => ({ bears: state.bears + 1 })),
-    decreasePopulation: () => set(state => ({ bears: state.bears - 1 })),
-    removeAllBears: () => set({ bears: 0 }),
-  }))
+  undoMiddleware(
+    set => ({
+      bears: 0,
+      ignored: 0,
+      increasePopulation: () =>
+        set(state => ({ bears: state.bears + 1, ignored: state.ignored + 1 })),
+      decreasePopulation: () =>
+        set(state => ({ bears: state.bears - 1, ignored: state.ignored - 1 })),
+      removeAllBears: () => set({ bears: 0 }),
+    }),
+    ['ignored']
+  )
 );
 
 const App = () => {
   const store = useStore();
   const {
     bears,
+    ignored,
     increasePopulation,
     removeAllBears,
     decreasePopulation,
@@ -61,6 +69,8 @@ const App = () => {
       <br />
       <br />
       bears: {bears}
+      <br />
+      ignored: {ignored}
       <br />
       <button onClick={increasePopulation}>increase</button>
       <button onClick={decreasePopulation}>decrease</button>


### PR DESCRIPTION
Pass a second argument to undoMiddleware that is an array of keys that are on your undo store state interface that will not be tracked in history.

there are some todo's there because I couldn't get the types to work perfectly. 

usage:
```tsx
const useStore = create<StoreState>(
  undoMiddleware(
    set => ({ ... }),
    { omit: ['field1', 'field2'] }
  )
);
```

Closes #8 