### PR TITLE
Fix/cool off tests

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -18,7 +18,7 @@ export interface UndoStoreState {
   // handle on the parent store's getter
   getStore: Function;
   options?: Options;
-  coolOffTimer?: NodeJS.Timeout;
+  coolOffTimer?: number;
   isCoolingOff?: boolean;
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -87,7 +87,7 @@ export const undoMiddleware = <TState extends UndoState>(
 
         setState({
           isCoolingOff: true,
-          coolOffTimer: setTimeout(() => {
+          coolOffTimer: window.setTimeout(() => {
       
             setState({
               isCoolingOff: false,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -39,7 +39,7 @@ export const undoMiddleware = <TState extends UndoState>(
         setIsUndoHistoryEnabled,
         isUndoHistoryEnabled,
         isCoolingOff,
-        coolOffTimer
+        coolOffTimer,
       } = getState();
       // inject helper functions to user defined store.
       set({
@@ -88,12 +88,11 @@ export const undoMiddleware = <TState extends UndoState>(
         setState({
           isCoolingOff: true,
           coolOffTimer: window.setTimeout(() => {
-      
             setState({
               isCoolingOff: false,
             });
           }, options?.coolOffDurationMs),
-        })
+        });
       }
     },
     get,

--- a/test/middleware.test.tsx
+++ b/test/middleware.test.tsx
@@ -50,4 +50,25 @@ describe('zundo store', () => {
     rerender();
     expect(result.current.bears).toBe(0);
   });
+
+  test('increment many without wait (no cool off)', async () => {
+    expect(result.current.bears).toBe(0);
+    act(() => {
+      result.current.increasePopulation();
+      result.current.increasePopulation();
+      result.current.increasePopulation();
+    });
+    rerender();
+    expect(result.current.bears).toBe(3);
+  });
+
+  test('undo after many added without wait (no cool off)', async () => {
+    rerender();
+    expect(result.current.bears).toBe(3);
+    act(() => {
+      result.current.undo?.();
+    });
+    rerender();
+    expect(result.current.bears).toBe(0);
+  });
 });

--- a/test/middleware.test.tsx
+++ b/test/middleware.test.tsx
@@ -13,7 +13,7 @@ describe('zundo store', () => {
       rerender();
       expect(result.current.bears).toBe(i + 1);
 
-      // Wait 1 ms between actions for zundo cool-off 
+      // Wait 1 ms between actions for zundo cool-off
       await new Promise((r) => setTimeout(r, 1));
     }
   });
@@ -27,7 +27,7 @@ describe('zundo store', () => {
       rerender();
       expect(result.current.bears).toBe(i - 1);
 
-      // Wait 1 ms between actions for zundo cool-off 
+      // Wait 1 ms between actions for zundo cool-off
       await new Promise((r) => setTimeout(r, 1));
     }
   });

--- a/test/middleware.test.tsx
+++ b/test/middleware.test.tsx
@@ -4,7 +4,7 @@ import { renderHook, act } from '@testing-library/react-hooks';
 describe('zundo store', () => {
   const { result, rerender } = renderHook(() => useStore());
 
-  test('increment', () => {
+  test('increment', async () => {
     for (let i = 0; i < 6; i++) {
       expect(result.current.bears).toBe(i);
       act(() => {
@@ -12,10 +12,13 @@ describe('zundo store', () => {
       });
       rerender();
       expect(result.current.bears).toBe(i + 1);
+
+      // Wait 1 ms between actions for zundo cool-off 
+      await new Promise((r) => setTimeout(r, 1));
     }
   });
 
-  test('decrement', () => {
+  test('decrement', async () => {
     for (let i = 6; i > 0; i--) {
       expect(result.current.bears).toBe(i);
       act(() => {
@@ -23,6 +26,9 @@ describe('zundo store', () => {
       });
       rerender();
       expect(result.current.bears).toBe(i - 1);
+
+      // Wait 1 ms between actions for zundo cool-off 
+      await new Promise((r) => setTimeout(r, 1));
     }
   });
 


### PR DESCRIPTION
Fixed two issues regarding tests:

- When I ran tests locally on my machine, I wasn't getting the same type error you were showing me. However I think this is down to which environment the tests were running in, and how `setTimeout` is treated depending on whether it's node or browser.  Using `window.setTimeout` is more explicit, and then the type changes to `number`. I can't say for sure it will work when the deployment tests run, but I think it should
- The actual unit tests were failing. This was because "undo" no longer did anything due to the cool-off period. I added a 1ms delay between increments/decrements so it registered properly. I also added some extra tests without the delay to test the cool-off.