### PR TITLE
Replaced omit with exclude and include

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,29 +73,41 @@ const useStoreWithUndo = create<StoreState>(
     bears: 0,
     increasePopulation: () => set((state) => ({ bears: state.bears + 1 })),
     removeAllBears: () => set({ bears: 0 }),
-  }))
+  })),
 );
 ```
 
 ### Middleware Options
 
 ```tsx
-options: { omit?: string[], allowUnchanged?: boolean, historyDepthLimit?: number }
+options: { exclude?: string[], include?: string[], allowUnchanged?: boolean, historyDepthLimit?: number }
 ```
 
-#### **Omit fields from being tracked in history**
+#### **Exclude fields from being tracked in history**
 
-Some fields you may not want to track in history and they can be ignored by zundo middleware.
-The second `options` parameter for `undoMiddleware` contains an `omit` field which is an array of string of keys on `StoreState` to be omitted from being tracked in history. By default, nothing is omitted (empty array).
+Use the `exclude` option, which accepts an array of keys to not track. Alternatively you can use the `include` option which will result in only those keys being tracked.
+
+_If for some reason you use both parameters, any key included in both will be excluded._
 
 ```tsx
-const useStore = create<StoreState>(
+// Only field1 and field2 will be tracked
+const useStoreA = create<StoreState>(
   undoMiddleware(
     set => ({ ... }),
-    { omit: ['field1', 'field2'] }
+    { include: ['field1', 'field2'] }
+  )
+);
+
+// Everything besides field1 and field2 will be tracked
+const useStoreB = create<StoreState>(
+  undoMiddleware(
+    set => ({ ... }),
+    { exclude: ['field1', 'field2'] }
   )
 );
 ```
+
+_Note: `exclude` replaces the option `omit` which will deprecated in future versions._
 
 #### **Allow unchanged states to be stored**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zundo",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "private": false,
   "description": "🍜 undo/redo middleware for zustand",
   "keywords": [

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -39,7 +39,7 @@ const handleStoreUpdates = (
       // pop front
       otherActionStates.shift();
     }
-    otherActionStates.push(filterState(getStore(), options?.omit));
+    otherActionStates.push(filterState(getStore(), options));
     const currentStoreState = currentActionStates.pop();
     setStore(currentStoreState);
   }
@@ -71,7 +71,7 @@ export const createUndoStore = () =>
     },
     setIsUndoHistoryEnabled: (isEnabled) => {
       const { prevStates, getStore, options } = get();
-      const currState = filterState(getStore(), options?.omit);
+      const currState = filterState(getStore(), options);
 
       set({
         isUndoHistoryEnabled: isEnabled,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -43,12 +43,12 @@ export const undoMiddleware =
         });
 
         // Get the last state before updating state
-        const lastState = filterState({ ...get() }, options?.omit);
+        const lastState = filterState({ ...get() }, options);
 
         set(args);
 
         // Get the current state after updating state
-        const currState = filterState({ ...get() }, options?.omit);
+        const currState = filterState({ ...get() }, options);
 
         // Only store changes if state isn't equal (or option has been set)
         const shouldStoreChange =

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,9 @@
 export interface Options {
-  // TODO: improve this type. ignored should only be fields on TState
-  omit?: string[];
+  include?: string[];
+  exclude?: string[];
   allowUnchanged?: boolean;
   historyDepthLimit?: number;
   coolOffDurationMs?: number;
+  // Will be deprecated eventually
+  omit?: string[]; // Use exclude
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@ export interface Options {
   allowUnchanged?: boolean;
   historyDepthLimit?: number;
   coolOffDurationMs?: number;
-  // Will be deprecated eventually
-  omit?: string[]; // Use exclude
+  /**
+   * @deprecated Use exclude instead.
+   */
+  omit?: string[];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,17 @@
+import { Options } from './types';
+
 // TODO: make this a better type
-export const filterState = (state: any, ignored: string[] = []) => {
+export const filterState = (state: any, options?: Options) => {
+  const excluded: string[] | undefined = options?.exclude || options?.omit;
+  const included: string[] | undefined = options?.include;
+
   const filteredState: any = {};
 
   Object.keys(state).forEach((key: string) => {
-    if (!ignored.includes(key)) {
+    if (
+      !(excluded && excluded.includes(key)) &&
+      (!included || included.includes(key))
+    ) {
       filteredState[key] = state[key];
     }
   });

--- a/stories/allow-unchanged.stories.tsx
+++ b/stories/allow-unchanged.stories.tsx
@@ -47,7 +47,7 @@ const useStore = create<StoreState>(
       doNothing: () => set((state) => ({ ...state })),
       removeAllBears: () => set({ bears: 0 }),
     }),
-    { omit: ['ignored'], allowUnchanged: true },
+    { exclude: ['ignored'], allowUnchanged: true },
   ),
 );
 

--- a/stories/bears.stories.tsx
+++ b/stories/bears.stories.tsx
@@ -47,7 +47,7 @@ export const useStore = create<StoreState>(
       doNothing: () => set((state) => ({ ...state })),
       removeAllBears: () => set({ bears: 0 }),
     }),
-    { omit: ['ignored'], historyDepthLimit: 10 },
+    { exclude: ['ignored'], historyDepthLimit: 10 },
   ),
 );
 

--- a/stories/bees.stories.tsx
+++ b/stories/bees.stories.tsx
@@ -30,18 +30,25 @@ interface StoreState extends UndoState {
 
 // create a store with undo middleware
 const useStoreWithUndo = create<StoreState>(
-  undoMiddleware((set) => ({
-    bees: 0,
-    text: '',
-    incrementBees: () => set((state) => ({ bees: state.bees + 1 })),
-    decrementBees: () => set((state) => ({ bees: state.bees - 1 })),
-    submitText: (text) => set({ text }),
-  })),
+  undoMiddleware(
+    (set) => ({
+      ignored: 0,
+      bees: 0,
+      text: '',
+      incrementBees: () =>
+        set((state) => ({ bees: state.bees + 1, ignored: state.ignored + 1 })),
+      decrementBees: () =>
+        set((state) => ({ bees: state.bees - 1, ignored: state.ignored - 1 })),
+      submitText: (text) => set({ text }),
+    }),
+    { include: ['bees', 'text'] },
+  ),
 );
 
 const App = () => {
   const {
     bees,
+    ignored,
     incrementBees,
     decrementBees,
     submitText,
@@ -58,6 +65,8 @@ const App = () => {
       <br />
       <br />
       bees: {bees}
+      <br />
+      ignored: {ignored}
       <br />
       <button type="button" onClick={incrementBees}>
         incremenet

--- a/stories/bees.stories.tsx
+++ b/stories/bees.stories.tsx
@@ -21,6 +21,7 @@ const meta: Meta = {
 export default meta;
 
 interface StoreState extends UndoState {
+  ignored: number;
   bees: number;
   text: string;
   incrementBees: () => void;


### PR DESCRIPTION
### Summary
Replaces omit (still functional) with exclude and adds the option to include keys.

### Why?
This was a [requested feature](https://github.com/charkour/zundo/issues/26) and makes a lot of sense for complex stores. I opted for the names exclude/include as over whitelist/blacklist because I feel they are clearer.

### Breaking Changes
None! 🎉
Omit is still a usable options but the documentation has been updated warning developers not to use it anymore.

### Tests
There were no existing tests for omit and I haven't added any new ones here. I did however update the storybook to use include for the bees example.

### Notes
@charkour Not sure if there are issues with this but I noticed that the filtered state contains (and with the new includes option now sometimes doesn't contain) the actions `redo`, `undo`, etc. I'm not sure if this is necessarily a problem but for consistency I think it makes sense to either always include or exclude these from the filtered state regardless of the options. I'll leave it up to you to make the call on which.