### PR TITLE
Support devtools named actions

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -41,7 +41,7 @@ const handleStoreUpdates = (
     }
     otherActionStates.push(filterState(getStore(), options));
     const currentStoreState = currentActionStates.pop();
-    setStore(currentStoreState);
+    setStore(currentStoreState, false, action);
   }
 };
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -21,7 +21,7 @@ export const undoMiddleware =
     const { getState, setState } = undoStore;
 
     return config(
-      (args) => {
+      (...args) => {
         /* TODO: const, should call this function and inject the values once, but it does
       it on every action call currently. */
         const {
@@ -44,8 +44,8 @@ export const undoMiddleware =
 
         // Get the last state before updating state
         const lastState = filterState({ ...get() }, options);
-
-        set(args);
+        
+        set(...args);
 
         // Get the current state after updating state
         const currState = filterState({ ...get() }, options);

--- a/stories/devtools.stories.tsx
+++ b/stories/devtools.stories.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { Meta, Story } from '@storybook/react';
+import create from 'zustand';
+import { devtools } from 'zustand/middleware';
+import { undoMiddleware, UndoState } from '../src';
+
+const meta: Meta = {
+  title: 'devtools',
+  argTypes: {
+    children: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
+  parameters: {
+    controls: { expanded: true },
+  },
+};
+
+export default meta;
+
+export interface StoreState extends UndoState {
+  bears: number;
+  ignored: number;
+  increasePopulation: () => void;
+  removeAllBears: () => void;
+  decreasePopulation: () => void;
+  doNothing: () => void;
+}
+
+// create a store with undo middleware
+const useStore = create<StoreState>(
+  devtools(
+    undoMiddleware(
+      (set) => ({
+        bears: 0,
+        ignored: 0,
+        increasePopulation: () =>
+          set(
+            (state) => ({
+              bears: state.bears + 1,
+              ignored: state.ignored + 1,
+            }),
+            false,
+            'increasePopulation',
+          ),
+        decreasePopulation: () =>
+          set(
+            (state) => ({
+              bears: state.bears - 1,
+              ignored: state.ignored - 1,
+            }),
+            false,
+            'decreasePopulation',
+          ),
+        doNothing: () => set((state) => ({ ...state })),
+        removeAllBears: () => set({ bears: 0 }),
+      }),
+      { exclude: ['ignored'], historyDepthLimit: 10 },
+    ),
+    { name: 'Zundo Example' },
+  ),
+);
+
+const App = () => {
+  const store = useStore();
+  const {
+    bears,
+    ignored,
+    increasePopulation,
+    removeAllBears,
+    decreasePopulation,
+    undo,
+    clear,
+    redo,
+    setIsUndoHistoryEnabled,
+    getState,
+    doNothing,
+  } = store;
+
+  return (
+    <div>
+      <h1>🐻 ♻️ Zundo!</h1>
+      previous states: {JSON.stringify(getState && getState().prevStates)}
+      <br />
+      {/* TODO: make the debug testing better */}
+      future states: {JSON.stringify(getState && getState().futureStates)}
+      <br />
+      current state: {JSON.stringify(store)}
+      <br />
+      bears: {bears}
+      <br />
+      ignored: {ignored}
+      <br />
+      <button type="button" onClick={increasePopulation}>
+        increase
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          increasePopulation();
+          increasePopulation();
+          increasePopulation();
+        }}
+      >
+        increase +3
+      </button>
+      <button type="button" onClick={decreasePopulation}>
+        decrease
+      </button>
+      <button type="button" onClick={removeAllBears}>
+        remove
+      </button>
+      <br />
+      <button type="button" onClick={undo}>
+        undo
+      </button>
+      <button type="button" onClick={redo}>
+        redo
+      </button>
+      <br />
+      <button type="button" onClick={clear}>
+        clear
+      </button>
+      <br />
+      <button
+        type="button"
+        onClick={() => {
+          setIsUndoHistoryEnabled?.(false);
+        }}
+      >
+        Disable History
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setIsUndoHistoryEnabled?.(true);
+        }}
+      >
+        Enable History
+      </button>
+      <br />
+      <button type="button" onClick={doNothing}>
+        do nothing
+      </button>
+    </div>
+  );
+};
+
+const Template: Story<{}> = (args) => <App {...args} />;
+
+// By passing using the Args format for exported stories, you can control the props for a component for reuse in a test
+// https://storybook.js.org/docs/react/workflows/unit-testing
+export const Default = Template.bind({});
+
+Default.args = {};

--- a/stories/other-middlewares.stories.tsx
+++ b/stories/other-middlewares.stories.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { Meta, Story } from '@storybook/react';
+import create, { StoreApi, GetState } from 'zustand';
+import { devtools, NamedSet, subscribeWithSelector } from 'zustand/middleware';
+
+import { undoMiddleware, UndoState } from '../src';
+
+const meta: Meta = {
+  title: 'Other Middlewares',
+  argTypes: {
+    children: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
+  parameters: {
+    controls: { expanded: true },
+  },
+};
+
+export default meta;
+
+export interface StoreState extends UndoState {
+  bears: number;
+  ignored: number;
+  increasePopulation: () => void;
+  removeAllBears: () => void;
+  decreasePopulation: () => void;
+  doNothing: () => void;
+}
+
+const storeWithoutDevtools = subscribeWithSelector<
+  StoreState,
+  NamedSet<StoreState>,
+  GetState<StoreState>,
+  StoreApi<StoreState>
+>(
+  undoMiddleware(
+    (set) => ({
+      bears: 0,
+      ignored: 0,
+      increasePopulation: () =>
+        set(
+          (state) => ({
+            bears: state.bears + 1,
+            ignored: state.ignored + 1,
+          }),
+          false,
+          'increasePopulation',
+        ),
+      decreasePopulation: () =>
+        set(
+          (state) => ({
+            bears: state.bears - 1,
+            ignored: state.ignored - 1,
+          }),
+          false,
+          'decreasePopulation',
+        ),
+      doNothing: () => set((state) => ({ ...state })),
+      removeAllBears: () => set({ bears: 0 }),
+    }),
+    { exclude: ['ignored'], historyDepthLimit: 10 },
+  ),
+);
+
+// create a store with undo middleware
+const useStore = create(devtools(storeWithoutDevtools));
+
+const App = () => {
+  const store = useStore();
+  const {
+    bears,
+    ignored,
+    increasePopulation,
+    removeAllBears,
+    decreasePopulation,
+    undo,
+    clear,
+    redo,
+    setIsUndoHistoryEnabled,
+    getState,
+    doNothing,
+  } = store;
+
+  return (
+    <div>
+      <h1>🐻 ♻️ Zundo!</h1>
+      previous states: {JSON.stringify(getState && getState().prevStates)}
+      <br />
+      {/* TODO: make the debug testing better */}
+      future states: {JSON.stringify(getState && getState().futureStates)}
+      <br />
+      current state: {JSON.stringify(store)}
+      <br />
+      bears: {bears}
+      <br />
+      ignored: {ignored}
+      <br />
+      <button type="button" onClick={increasePopulation}>
+        increase
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          increasePopulation();
+          increasePopulation();
+          increasePopulation();
+        }}
+      >
+        increase +3
+      </button>
+      <button type="button" onClick={decreasePopulation}>
+        decrease
+      </button>
+      <button type="button" onClick={removeAllBears}>
+        remove
+      </button>
+      <br />
+      <button type="button" onClick={undo}>
+        undo
+      </button>
+      <button type="button" onClick={redo}>
+        redo
+      </button>
+      <br />
+      <button type="button" onClick={clear}>
+        clear
+      </button>
+      <br />
+      <button
+        type="button"
+        onClick={() => {
+          setIsUndoHistoryEnabled?.(false);
+        }}
+      >
+        Disable History
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setIsUndoHistoryEnabled?.(true);
+        }}
+      >
+        Enable History
+      </button>
+      <br />
+      <button type="button" onClick={doNothing}>
+        do nothing
+      </button>
+    </div>
+  );
+};
+
+const Template: Story<{}> = (args) => <App {...args} />;
+
+// By passing using the Args format for exported stories, you can control the props for a component for reuse in a test
+// https://storybook.js.org/docs/react/workflows/unit-testing
+export const Default = Template.bind({});
+
+Default.args = {};


### PR DESCRIPTION
Currently `undoMiddleware` only passes on the first argument for `set`, stopping devtools from being able to [display named actions](https://github.com/pmndrs/zustand#logging-actions). This PR passes on all arguments for `set` by spreading them (`...args`).

List of things that this PR does:
- Passes on all arguments for `set`
- Adds names for both `undo` and `redo`, so they are named in devtools
- Conditionally injects helper functions (halving the number of reported actions in devtools)
- Names action that injects helper functions "injectZundoHelpers" (should only ever be seen once in devtools)
- Updates type from `SetState` to `NamedSet` where relevant
- Adds storybook item with `devtools` middleware and named actions]

I have tested this both in the storybook and my own project usage of `zundo` and it seems to work well. When not using `devtools`, it doesn't seem to cause any issues, although this is the one area that slightly concerns me. I have just swapped the types rather than doing any sort of conditional typing, and I've added names for `undo` and `redo` without checking if `devtools` is actually being used. 

