### PR TITLE
fix step bug not reversing order

### DIFF
--- a/packages/zundo/__tests__/zundo.test.ts
+++ b/packages/zundo/__tests__/zundo.test.ts
@@ -91,15 +91,19 @@ describe('temporal middleware', () => {
         store.getState().increment();
         store.getState().increment();
         store.getState().increment();
+        store.getState().increment();
+        store.getState().increment();
+        store.getState().increment();
       });
-      expect(store.temporal.getState().pastStates.length).toBe(3);
+      expect(store.temporal.getState().pastStates.length).toBe(6);
+      act(() => {
+        undo(4);
+      });
+      expect(store.temporal.getState().pastStates.length).toBe(2);
+      expect(store.getState().count).toBe(2);
+      expect(store.temporal.getState().futureStates.map((state) => state.count)).toEqual([6, 5, 4, 3]);
       act(() => {
         undo(2);
-      });
-      expect(store.temporal.getState().pastStates.length).toBe(1);
-      expect(store.getState().count).toBe(1);
-      act(() => {
-        undo();
       });
       expect(store.temporal.getState().pastStates.length).toBe(0);
       expect(store.getState().count).toBe(0);
@@ -132,19 +136,23 @@ describe('temporal middleware', () => {
         store.getState().increment();
         store.getState().increment();
         store.getState().increment();
+        store.getState().increment();
+        store.getState().increment();
+        store.getState().increment();
       });
-      expect(store.temporal.getState().pastStates.length).toBe(3);
+      expect(store.temporal.getState().pastStates.length).toBe(6);
       act(() => {
-        undo(2);
+        undo(4);
       });
-      expect(store.temporal.getState().pastStates.length).toBe(1);
-      expect(store.getState().count).toBe(1);
-      expect(store.temporal.getState().futureStates.length).toBe(2);
+      expect(store.temporal.getState().pastStates.length).toBe(2);
+      expect(store.getState().count).toBe(2);
+      expect(store.temporal.getState().futureStates.length).toBe(4);
       act(() => {
-        redo(2);
+        redo(4);
       });
-      expect(store.temporal.getState().pastStates.length).toBe(3);
-      expect(store.getState().count).toBe(3);
+      expect(store.temporal.getState().pastStates.length).toBe(6);
+      expect(store.temporal.getState().pastStates.map((state) => state.count)).toEqual([0, 1, 2, 3, 4, 5]);
+      expect(store.getState().count).toBe(6);
     });
   });
 

--- a/packages/zundo/package.json
+++ b/packages/zundo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zundo",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "private": false,
   "description": "🍜 undo/redo middleware for zustand",
   "keywords": [

--- a/packages/zundo/src/temporal.ts
+++ b/packages/zundo/src/temporal.ts
@@ -37,7 +37,7 @@ export const createVanillaTemporal = <TState>(
           userSet(pastState);
         }
 
-        fs.push(...skippedPastStates);
+        fs.push(...skippedPastStates.reverse());
         set({ pastStates: ps, futureStates: fs });
       },
       redo: (steps = 1) => {
@@ -56,7 +56,7 @@ export const createVanillaTemporal = <TState>(
           userSet(futureState);
         }
 
-        ps.push(...skippedFutureStates);
+        ps.push(...skippedFutureStates.reverse());
         set({ pastStates: ps, futureStates: fs });
       },
       clear: () => {


### PR DESCRIPTION
- Adds tests to make sure state are applied in the correct order when using `undo(step)` and `redo(step)`

fixes #59