### PR TITLE
switch config for better types and save bytes

### DIFF
--- a/packages/zundo/__tests__/options.test.ts
+++ b/packages/zundo/__tests__/options.test.ts
@@ -431,11 +431,10 @@ describe('Middleware options', () => {
 
   describe('secret internals', () => {
     it('should have a secret internal state', () => {
-      const { __internal } =
+      const { __handleUserSet, __onSave } =
         store.temporal.getState() as TemporalStateWithInternals<MyState>;
-      expect(__internal).toBeDefined();
-      expect(__internal.handleUserSet).toBeInstanceOf(Function);
-      expect(__internal.onSave).toBe(undefined);
+      expect(__handleUserSet).toBeInstanceOf(Function);
+      expect(__onSave).toBe(undefined);
     });
     describe('onSave', () => {
       it('should call onSave cb without adding a new state when onSave is set by user', () => {
@@ -446,13 +445,12 @@ describe('Middleware options', () => {
             console.error(pastStates, currentState);
           });
         });
-        const { __internal } =
+        const { __onSave } =
           store.temporal.getState() as TemporalStateWithInternals<MyState>;
-        const { onSave } = __internal;
         act(() => {
-          onSave(store.getState(), store.getState());
+          __onSave(store.getState(), store.getState());
         });
-        expect(__internal.onSave).toBeInstanceOf(Function);
+        expect(__onSave).toBeInstanceOf(Function);
         expect(store.temporal.getState().pastStates.length).toBe(0);
         expect(console.error).toHaveBeenCalledTimes(1);
       });
@@ -463,11 +461,10 @@ describe('Middleware options', () => {
             console.info(pastStates);
           },
         });
-        const { __internal } =
+        const { __onSave } =
           storeWithOnSave.temporal.getState() as TemporalStateWithInternals<MyState>;
-        const { onSave } = __internal;
         act(() => {
-          onSave(storeWithOnSave.getState(), storeWithOnSave.getState());
+          __onSave(storeWithOnSave.getState(), storeWithOnSave.getState());
         });
         expect(storeWithOnSave.temporal.getState().pastStates.length).toBe(0);
         expect(console.error).toHaveBeenCalledTimes(1);
@@ -483,7 +480,7 @@ describe('Middleware options', () => {
         act(() => {
           (
             storeWithOnSave.temporal.getState() as TemporalStateWithInternals<MyState>
-          ).__internal.onSave(
+          ).__onSave(
             storeWithOnSave.getState(),
             storeWithOnSave.getState(),
           );
@@ -501,7 +498,7 @@ describe('Middleware options', () => {
         act(() => {
           (
             storeWithOnSave.temporal.getState() as TemporalStateWithInternals<MyState>
-          ).__internal.onSave(store.getState(), store.getState());
+          ).__onSave(store.getState(), store.getState());
         });
         expect(store.temporal.getState().pastStates.length).toBe(0);
         expect(console.dir).toHaveBeenCalledTimes(1);
@@ -511,31 +508,29 @@ describe('Middleware options', () => {
 
     describe('handleUserSet', () => {
       it('should update the temporal store with the pastState when called', () => {
-        const { __internal } =
+        const { __handleUserSet } =
           store.temporal.getState() as TemporalStateWithInternals<MyState>;
-        const { handleUserSet } = __internal;
         act(() => {
-          handleUserSet(store.getState());
+          __handleUserSet(store.getState());
         });
         expect(store.temporal.getState().pastStates.length).toBe(1);
       });
 
       it('should only update if the the status is tracking', () => {
-        const { __internal } =
+        const { __handleUserSet } =
           store.temporal.getState() as TemporalStateWithInternals<MyState>;
-        const { handleUserSet } = __internal;
         act(() => {
-          handleUserSet(store.getState());
+          __handleUserSet(store.getState());
         });
         expect(store.temporal.getState().pastStates.length).toBe(1);
         act(() => {
           store.temporal.getState().pause();
-          handleUserSet(store.getState());
+          __handleUserSet(store.getState());
         });
         expect(store.temporal.getState().pastStates.length).toBe(1);
         act(() => {
           store.temporal.getState().resume();
-          handleUserSet(store.getState());
+          __handleUserSet(store.getState());
         });
       });
 

--- a/packages/zundo/__tests__/options.test.ts
+++ b/packages/zundo/__tests__/options.test.ts
@@ -431,9 +431,9 @@ describe('Middleware options', () => {
 
   describe('secret internals', () => {
     it('should have a secret internal state', () => {
-      const { __handleUserSet, __onSave } =
+      const { __handleSet, __onSave } =
         store.temporal.getState() as TemporalStateWithInternals<MyState>;
-      expect(__handleUserSet).toBeInstanceOf(Function);
+      expect(__handleSet).toBeInstanceOf(Function);
       expect(__onSave).toBe(undefined);
     });
     describe('onSave', () => {
@@ -508,29 +508,29 @@ describe('Middleware options', () => {
 
     describe('handleUserSet', () => {
       it('should update the temporal store with the pastState when called', () => {
-        const { __handleUserSet } =
+        const { __handleSet } =
           store.temporal.getState() as TemporalStateWithInternals<MyState>;
         act(() => {
-          __handleUserSet(store.getState());
+          __handleSet(store.getState());
         });
         expect(store.temporal.getState().pastStates.length).toBe(1);
       });
 
       it('should only update if the the status is tracking', () => {
-        const { __handleUserSet } =
+        const { __handleSet } =
           store.temporal.getState() as TemporalStateWithInternals<MyState>;
         act(() => {
-          __handleUserSet(store.getState());
+          __handleSet(store.getState());
         });
         expect(store.temporal.getState().pastStates.length).toBe(1);
         act(() => {
           store.temporal.getState().pause();
-          __handleUserSet(store.getState());
+          __handleSet(store.getState());
         });
         expect(store.temporal.getState().pastStates.length).toBe(1);
         act(() => {
           store.temporal.getState().resume();
-          __handleUserSet(store.getState());
+          __handleSet(store.getState());
         });
       });
 

--- a/packages/zundo/src/index.ts
+++ b/packages/zundo/src/index.ts
@@ -56,7 +56,7 @@ const zundoImpl =
     store.temporal = temporalStore;
 
     const curriedUserLandSet = userlandSetFactory(
-      temporalStore.getState().__internal.handleUserSet,
+      temporalStore.getState().__handleUserSet,
     );
 
     const modifiedSetState: typeof setState = (state, replace) => {

--- a/packages/zundo/src/index.ts
+++ b/packages/zundo/src/index.ts
@@ -5,7 +5,12 @@ import type {
   StoreApi,
 } from 'zustand';
 import { createVanillaTemporal } from './temporal';
-import type { TemporalState, Write, ZundoOptions } from './types';
+import type {
+  TemporalState,
+  TemporalStateWithInternals,
+  Write,
+  ZundoOptions,
+} from './types';
 
 type Zundo = <
   TState,
@@ -27,54 +32,59 @@ declare module 'zustand/vanilla' {
   }
 }
 
-const zundoImpl =
-  <TState>(
-    config: StateCreator<TState, [], []>,
-    {
-      partialize = (state: TState) => state,
-      handleSet: userlandSetFactory = (handleSetCb) => handleSetCb,
-      ...restOptions
-    } = {} as ZundoOptions<TState>,
-  ): StateCreator<TState, [], []> =>
-  (set, get, _store) => {
-    type TState = ReturnType<typeof config>;
-    type StoreAddition = StoreApi<TemporalState<TState>>;
-
-    const temporalStore = createVanillaTemporal<TState>(set, get, {
+const zundoImpl = <TState>(
+  config: StateCreator<TState, [], []>,
+  {
+    partialize = (state: TState) => state,
+    handleSet = (handleSetCb) => handleSetCb,
+    ...restOptions
+  } = {} as ZundoOptions<TState>,
+): StateCreator<TState, [], []> => {
+  type StoreAddition = StoreApi<TemporalState<TState>>;
+  type StoreWithAddition = Mutate<
+    StoreApi<TState>,
+    [['temporal', StoreAddition]]
+  >;
+  const configWithTemporal = (
+    set: StoreApi<TState>['setState'],
+    get: StoreApi<TState>['getState'],
+    store: StoreWithAddition,
+  ) => {
+    store.temporal = createVanillaTemporal<TState>(set, get, {
       partialize,
       ...restOptions,
     });
 
-    const store = _store as Mutate<
-      StoreApi<TState>,
-      [['temporal', StoreAddition]]
-    >;
+    const curriedUserLandSet = handleSet(
+      (store.temporal.getState() as TemporalStateWithInternals<TState>)
+      .__handleUserSet,
+      );
+
     const { setState } = store;
-
-    // TODO: should temporal be only temporalStore.getState()?
-    // We can hide the rest of the store in the secret internals.
-    store.temporal = temporalStore;
-
-    const curriedUserLandSet = userlandSetFactory(
-      temporalStore.getState().__handleUserSet,
-    );
-
-    const modifiedSetState: typeof setState = (state, replace) => {
+    // Modify the setState function to call the userlandSet function
+    store.setState = (state, replace) => {
+      // Get most up to date state. The state from the callback might be a partial state.
+      // The order of the get() and set() calls is important here.
       const pastState = partialize(get());
       setState(state, replace);
       curriedUserLandSet(pastState);
     };
-    store.setState = modifiedSetState;
 
-    const modifiedSetter: typeof set = (state, replace) => {
-      // Get most up to date state. Should this be the same as the state in the callback?
-      const pastState = partialize(get());
-      set(state, replace);
-      curriedUserLandSet(pastState);
-    };
-
-    return config(modifiedSetter, get, _store);
+    return config(
+      // Modify the set function to call the userlandSet function
+      (state, replace) => {
+        // Get most up to date state. The state from the callback might be a partial state.
+        // The order of the get() and set() calls is important here.
+        const pastState = partialize(get());
+        set(state, replace);
+        curriedUserLandSet(pastState);
+      },
+      get,
+      store,
+    );
   };
+  return configWithTemporal as StateCreator<TState, [], []>;
+};
 
 export const temporal = zundoImpl as unknown as Zundo;
 export type { ZundoOptions, Zundo, TemporalState };

--- a/packages/zundo/src/index.ts
+++ b/packages/zundo/src/index.ts
@@ -55,9 +55,9 @@ const zundoImpl = <TState>(
       ...restOptions,
     });
 
-    const curriedUserLandSet = handleSet(
+    const curriedHandleSet = handleSet(
       (store.temporal.getState() as TemporalStateWithInternals<TState>)
-      .__handleUserSet,
+      .__handleSet,
       );
 
     const { setState } = store;
@@ -67,7 +67,7 @@ const zundoImpl = <TState>(
       // The order of the get() and set() calls is important here.
       const pastState = partialize(get());
       setState(state, replace);
-      curriedUserLandSet(pastState);
+      curriedHandleSet(pastState);
     };
 
     return config(
@@ -77,7 +77,7 @@ const zundoImpl = <TState>(
         // The order of the get() and set() calls is important here.
         const pastState = partialize(get());
         set(state, replace);
-        curriedUserLandSet(pastState);
+        curriedHandleSet(pastState);
       },
       get,
       store,

--- a/packages/zundo/src/temporal.ts
+++ b/packages/zundo/src/temporal.ts
@@ -67,18 +67,17 @@ export const createVanillaTemporal = <TState>(
       __onSave: onSave,
       __handleUserSet: (pastState) => {
         const { trackingStatus, pastStates, __onSave } = get();
-        const ps = pastStates.slice();
         const currentState = partialize(userGet());
         if (
           trackingStatus === 'tracking' &&
           !equality?.(currentState, pastState)
         ) {
-          if (limit && ps.length >= limit) {
-            ps.shift();
+          if (limit && pastStates.length >= limit) {
+            pastStates.shift();
           }
-          ps.push(pastState);
+          pastStates.push(pastState);
           __onSave?.(pastState, currentState);
-          set({ pastStates: ps, futureStates: [] });
+          set({ pastStates, futureStates: [] });
         }
       },
     };

--- a/packages/zundo/src/temporal.ts
+++ b/packages/zundo/src/temporal.ts
@@ -60,27 +60,26 @@ export const createVanillaTemporal = <TState>(
       resume: () => {
         set({ trackingStatus: 'tracking' });
       },
-      setOnSave: (onSave) => {
-        set((state) => ({ __internal: { ...state.__internal, onSave } }));
+      setOnSave: (__onSave) => {
+        set({ __onSave });
       },
-      __internal: {
-        onSave,
-        handleUserSet: (pastState) => {
-          const { trackingStatus, pastStates, __internal } = get();
-          const ps = pastStates.slice();
-          const currentState = partialize(userGet());
-          if (
-            trackingStatus === 'tracking' &&
-            !equality?.(currentState, pastState)
-          ) {
-            if (limit && ps.length >= limit) {
-              ps.shift();
-            }
-            ps.push(pastState);
-            __internal.onSave?.(pastState, currentState);
-            set({ pastStates: ps, futureStates: [] });
+      // Internal properties
+      __onSave: onSave,
+      __handleUserSet: (pastState) => {
+        const { trackingStatus, pastStates, __onSave } = get();
+        const ps = pastStates.slice();
+        const currentState = partialize(userGet());
+        if (
+          trackingStatus === 'tracking' &&
+          !equality?.(currentState, pastState)
+        ) {
+          if (limit && ps.length >= limit) {
+            ps.shift();
           }
-        },
+          ps.push(pastState);
+          __onSave?.(pastState, currentState);
+          set({ pastStates: ps, futureStates: [] });
+        }
       },
     };
   });

--- a/packages/zundo/src/temporal.ts
+++ b/packages/zundo/src/temporal.ts
@@ -17,38 +17,38 @@ export const createVanillaTemporal = <TState>(
       pastStates: [],
       futureStates: [],
       undo: (steps = 1) => {
-        const ps = get().pastStates.slice();
-        const fs = get().futureStates.slice();
-        if (ps.length === 0) {
+        const { futureStates, pastStates } = get();
+        if (pastStates.length === 0) {
           return;
         }
 
-        const skippedPastStates = ps.splice(ps.length - (steps - 1));
-        const pastState = ps.pop();
-        if (pastState) {
-          fs.push(partialize(userGet()));
-          userSet(pastState);
+        // Based on the steps, get values from the pastStates array and push them to the futureStates array
+        for (let i = 0; i < steps; i++) {
+          const pastState = pastStates.pop();
+          if (pastState) {
+            futureStates.push(partialize(userGet()));
+            userSet(pastState);
+          }
         }
 
-        fs.push(...skippedPastStates.reverse());
-        set({ pastStates: ps, futureStates: fs });
+        set({ pastStates, futureStates });
       },
       redo: (steps = 1) => {
-        const ps = get().pastStates.slice();
-        const fs = get().futureStates.slice();
-        if (fs.length === 0) {
+        const { futureStates, pastStates } = get();
+        if (futureStates.length === 0) {
           return;
         }
 
-        const skippedFutureStates = fs.splice(fs.length - (steps - 1));
-        const futureState = fs.pop();
-        if (futureState) {
-          ps.push(partialize(userGet()));
-          userSet(futureState);
+        // Based on the steps, get values from the futureStates array and push them to the pastStates array
+        for (let i = 0; i < steps; i++) {
+          const futureState = futureStates.pop();
+          if (futureState) {
+            pastStates.push(partialize(userGet()));
+            userSet(futureState);
+          }
         }
 
-        ps.push(...skippedFutureStates.reverse());
-        set({ pastStates: ps, futureStates: fs });
+        set({ pastStates, futureStates });
       },
       clear: () => {
         set({ pastStates: [], futureStates: [] });

--- a/packages/zundo/src/temporal.ts
+++ b/packages/zundo/src/temporal.ts
@@ -72,6 +72,7 @@ export const createVanillaTemporal = <TState>(
           trackingStatus === 'tracking' &&
           !equality?.(currentState, pastState)
         ) {
+          // This naively assumes that only one new state can be added at a time
           if (limit && pastStates.length >= limit) {
             pastStates.shift();
           }

--- a/packages/zundo/src/temporal.ts
+++ b/packages/zundo/src/temporal.ts
@@ -65,7 +65,7 @@ export const createVanillaTemporal = <TState>(
       },
       // Internal properties
       __onSave: onSave,
-      __handleUserSet: (pastState) => {
+      __handleSet: (pastState) => {
         const { trackingStatus, pastStates, __onSave } = get();
         const currentState = partialize(userGet());
         if (

--- a/packages/zundo/src/temporal.ts
+++ b/packages/zundo/src/temporal.ts
@@ -12,7 +12,7 @@ export const createVanillaTemporal = <TState>(
   } = {} as Omit<WithRequired<ZundoOptions<TState>, | 'partialize'>, 'handleSet'>,
 ) => {
 
-  return createStore<TemporalStateWithInternals<TState>>()((set, get) => {
+  return createStore<TemporalStateWithInternals<TState>>((set, get) => {
     return {
       pastStates: [],
       futureStates: [],

--- a/packages/zundo/src/types.ts
+++ b/packages/zundo/src/types.ts
@@ -15,10 +15,8 @@ export interface TemporalStateWithInternals<TState> {
   resume: () => void;
 
   setOnSave: (onSave: onSave<TState>) => void;
-  __internal: {
-    onSave: onSave<TState>;
-    handleUserSet: (pastState: TState) => void;
-  };
+  __onSave: onSave<TState>;
+  __handleUserSet: (pastState: TState) => void;
 }
 
 export interface ZundoOptions<TState, PartialTState = TState> {
@@ -35,7 +33,7 @@ export type Write<T, U> = Omit<T, keyof U> & U;
 
 export type TemporalState<TState> = Omit<
   TemporalStateWithInternals<TState>,
-  '__internal'
+  '__onSave' | '__handleUserSet'
 >;
 
 // https://stackoverflow.com/a/69328045/9931154

--- a/packages/zundo/src/types.ts
+++ b/packages/zundo/src/types.ts
@@ -16,7 +16,7 @@ export interface TemporalStateWithInternals<TState> {
 
   setOnSave: (onSave: onSave<TState>) => void;
   __onSave: onSave<TState>;
-  __handleUserSet: (pastState: TState) => void;
+  __handleSet: (pastState: TState) => void;
 }
 
 export interface ZundoOptions<TState, PartialTState = TState> {


### PR DESCRIPTION
more efficiencies 

868 B --> 862 B (save 4 bytes) Inline setters in index.ts
862 B --> 859 B (save 3 bytes) return a configWithTemporal object to remove `_store`
859 --> 855 B (save 4 bytes) assign to property rather than create variable in index.ts
855 --> 854 B (save 1 byte) remove curried zustand create in zundo.ts
853 --> 847 B (save 6 bytes) rename __handleUserSet to __handleSet
