### PR TITLE
move immer to root to fix broken examples from 8608dd94c5597588e38950

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "immer": "10.0.2",
     "lodash.merge": "4.6.2",
     "lodash.throttle": "4.1.1",
     "next": "13.4.3",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "npm": ">=7.0.0",
     "node": ">=14.0.0"
   },
-  "packageManager": "pnpm@6.32.25"
+  "packageManager": "pnpm@6.32.25",
+  "dependencies": {
+    "immer": "10.0.2"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,10 @@ lockfileVersion: '6.0'
 importers:
 
   .:
+    dependencies:
+      immer:
+        specifier: 10.0.2
+        version: 10.0.2
     devDependencies:
       eslint-config-custom:
         specifier: workspace:*
@@ -50,9 +54,6 @@ importers:
 
   apps/web:
     dependencies:
-      immer:
-        specifier: 10.0.2
-        version: 10.0.2
       lodash.merge:
         specifier: 4.6.2
         version: 4.6.2


### PR DESCRIPTION
Related to #96. Caused an issue with running examples