### PR TITLE
fix: don't call handleSet if state hasn't changed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,19 +74,19 @@ export const temporal = (<TState>(
         set(...args);
         const currentState = options?.partialize?.(get()) || get();
         const deltaState = options?.diff?.(pastState, currentState);
-        // Don't call handleSet if state hasn't changed
-          if (
-              !(
-              // If the user has provided an equality function, use it
-              (
-                  options?.equality?.(pastState, currentState) ||
-                  // If the user has provided a diff function but nothing has been changed, function returns null
-                  deltaState === null
-              )
+        // Don't call handleSet if state hasn't changed, as determined by equality or diff fn
+        if (
+          !(
+            // If the user has provided an equality function, use it
+            (
+              options?.equality?.(pastState, currentState) ||
+              // If the user has provided a diff function but nothing has been changed, function returns null
+              deltaState === null
+            )
           )
-          ) {
-              curriedHandleSet(pastState);
-          }
+        ) {
+          curriedHandleSet(pastState);
+        }
       },
       get,
       store,

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,21 @@ export const temporal = (<TState>(
         // The order of the get() and set() calls is important here.
         const pastState = options?.partialize?.(get()) || get();
         set(...args);
-        curriedHandleSet(pastState);
+        const currentState = options?.partialize?.(get()) || get();
+        const deltaState = options?.diff?.(pastState, currentState);
+        // Don't call handleSet if state hasn't changed
+          if (
+              !(
+              // If the user has provided an equality function, use it
+              (
+                  options?.equality?.(pastState, currentState) ||
+                  // If the user has provided a diff function but nothing has been changed, function returns null
+                  deltaState === null
+              )
+          )
+          ) {
+              curriedHandleSet(pastState);
+          }
       },
       get,
       store,

--- a/src/temporal.ts
+++ b/src/temporal.ts
@@ -62,27 +62,17 @@ export const temporalStateCreator = <TState>(
         if (get().isTracking) {
           const currentState = options?.partialize?.(userGet()) || userGet();
           const deltaState = options?.diff?.(pastState, currentState);
-          if (
-            !(
-              // If the user has provided an equality function, use it
-              (
-                options?.equality?.(pastState, currentState) ||
-                // If the user has provided a diff function but nothing has been changed, function returns null
-                deltaState === null
-              )
-            )
-          ) {
-            // This naively assumes that only one new state can be added at a time
-            if (options?.limit && get().pastStates.length >= options?.limit) {
-              get().pastStates.shift();
-            }
 
-            get()._onSave?.(pastState, currentState);
-            set({
-              pastStates: get().pastStates.concat(deltaState || pastState),
-              futureStates: [],
-            });
+          // This naively assumes that only one new state can be added at a time
+          if (options?.limit && get().pastStates.length >= options?.limit) {
+            get().pastStates.shift();
           }
+
+          get()._onSave?.(pastState, currentState);
+          set({
+            pastStates: get().pastStates.concat(deltaState || pastState),
+            futureStates: [],
+          });
         }
       },
     };

--- a/tests/__tests__/options.test.ts
+++ b/tests/__tests__/options.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
 vi.mock('zustand');
 import { temporal } from '../../src/index';
 import { createStore, type StoreApi } from 'zustand';
@@ -29,7 +30,8 @@ interface MyState {
   boolean1: boolean;
   boolean2: boolean;
   increment: () => void;
-  incrementOnly2: () => void;
+  incrementCountOnly: () => void;
+  incrementCount2Only: () => void;
   decrement: () => void;
   doNothing: () => void;
 }
@@ -56,7 +58,9 @@ const createVanillaStore = (
             count: state.count - 1,
             count2: state.count2 - 1,
           })),
-        incrementOnly2: () => set((state) => ({ count2: state.count2 + 1 })),
+        incrementCountOnly: () => set((state) => ({ count: state.count + 1 })),
+        incrementCount2Only: () =>
+          set((state) => ({ count2: state.count2 + 1 })),
         doNothing: () => set((state) => ({ ...state })),
       };
     }, options),
@@ -95,7 +99,8 @@ describe('Middleware options', () => {
         increment: expect.any(Function),
         decrement: expect.any(Function),
         doNothing: expect.any(Function),
-        incrementOnly2: expect.any(Function),
+        incrementCountOnly: expect.any(Function),
+        incrementCount2Only: expect.any(Function),
         myString: 'hello',
         string2: 'world',
         boolean1: true,
@@ -107,7 +112,8 @@ describe('Middleware options', () => {
         increment: expect.any(Function),
         decrement: expect.any(Function),
         doNothing: expect.any(Function),
-        incrementOnly2: expect.any(Function),
+        incrementCountOnly: expect.any(Function),
+        incrementCount2Only: expect.any(Function),
         myString: 'hello',
         string2: 'world',
         boolean1: true,
@@ -172,7 +178,8 @@ describe('Middleware options', () => {
         increment: expect.any(Function),
         decrement: expect.any(Function),
         doNothing: expect.any(Function),
-        incrementOnly2: expect.any(Function),
+        incrementCountOnly: expect.any(Function),
+        incrementCount2Only: expect.any(Function),
         boolean1: true,
         boolean2: false,
         myString: 'hello',
@@ -193,7 +200,8 @@ describe('Middleware options', () => {
         increment: expect.any(Function),
         decrement: expect.any(Function),
         doNothing: expect.any(Function),
-        incrementOnly2: expect.any(Function),
+        incrementCountOnly: expect.any(Function),
+        incrementCount2Only: expect.any(Function),
         boolean1: true,
         boolean2: false,
         myString: 'hello',
@@ -328,7 +336,8 @@ describe('Middleware options', () => {
           return isEmpty(newStateFromDiff) ? null : newStateFromDiff;
         },
       });
-      const { doNothing, increment, incrementOnly2 } = storeWithDiff.getState();
+      const { doNothing, increment, incrementCount2Only } =
+        storeWithDiff.getState();
       const { undo, redo } = storeWithDiff.temporal.getState();
       act(() => {
         doNothing();
@@ -355,7 +364,7 @@ describe('Middleware options', () => {
       });
       act(() => {
         doNothing();
-        incrementOnly2();
+        incrementCount2Only();
       });
       expect(storeWithDiff.temporal.getState().pastStates.length).toBe(3);
       expect(storeWithDiff.temporal.getState().pastStates[2]).toEqual({
@@ -367,7 +376,7 @@ describe('Middleware options', () => {
       });
       act(() => {
         doNothing();
-        incrementOnly2();
+        incrementCount2Only();
       });
       expect(storeWithDiff.temporal.getState().pastStates.length).toBe(4);
       expect(storeWithDiff.temporal.getState().pastStates[3]).toEqual({
@@ -677,6 +686,7 @@ describe('Middleware options', () => {
       expect(console.error).toHaveBeenCalledTimes(4);
       vi.useRealTimers();
     });
+
     it('should correctly use throttling (wrapTemporal)', () => {
       global.console.error = vi.fn();
       vi.useFakeTimers();
@@ -716,6 +726,184 @@ describe('Middleware options', () => {
         2,
       );
       expect(console.warn).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not call throttle function if partialized state is unchanged according to equality fn', () => {
+      global.console.error = vi.fn();
+      vi.useFakeTimers();
+      const throttleIntervalInMs = 1000;
+      const storeWithHandleSetAndPartializeAndEquality = createVanillaStore({
+        handleSet: (handleSet) => {
+          return throttle<typeof handleSet>(
+            (state) => {
+              // used for determining how many times `handleSet` is called
+              console.error('handleSet called');
+              handleSet(state);
+            },
+            throttleIntervalInMs,
+            // Call throttle only on leading edge of timeout
+            { leading: true, trailing: false },
+          );
+        },
+        partialize: (state) => ({
+          count: state.count,
+        }),
+        equality: (pastState, currentState) =>
+          diff(pastState, currentState).length === 0,
+      });
+
+      const { incrementCountOnly, incrementCount2Only } =
+        storeWithHandleSetAndPartializeAndEquality.getState();
+      // Increment value not included in partialized state
+      act(() => {
+        incrementCount2Only();
+      });
+      // Proxy for determining how many times `handleSet` is called.
+      // handleSet should not be called if partialized state is unchanged
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(
+        storeWithHandleSetAndPartializeAndEquality.temporal.getState()
+          .pastStates.length,
+      ).toBe(0);
+      // Advance timer to be within throttle interval
+      vi.advanceTimersByTime(throttleIntervalInMs / 2);
+      act(() => {
+        incrementCountOnly();
+      });
+      // Count is in partialized state, so handleSet should have been called
+      expect(console.error).toHaveBeenCalledTimes(1);
+      // The first instance of a partialized state changing should add to history
+      expect(
+        storeWithHandleSetAndPartializeAndEquality.temporal.getState()
+          .pastStates.length,
+      ).toBe(1);
+      vi.useRealTimers();
+    });
+
+    it('should not call throttle function if partialized state is unchanged according to diff fn', () => {
+      global.console.error = vi.fn();
+      vi.useFakeTimers();
+      const throttleIntervalInMs = 1000;
+      const storeWithHandleSetAndPartializeAndDiff = createVanillaStore({
+        handleSet: (handleSet) => {
+          return throttle<typeof handleSet>(
+            (state) => {
+              // used for determining how many times `handleSet` is called
+              console.error('handleSet called');
+              handleSet(state);
+            },
+            throttleIntervalInMs,
+            // Call throttle only on leading edge of timeout
+            { leading: true, trailing: false },
+          );
+        },
+        partialize: (state) => ({
+          count: state.count,
+        }),
+        diff: (pastState, currentState) => {
+          const myDiff = diff(currentState, pastState);
+          const newStateFromDiff = myDiff.reduce(
+            (acc, difference) => {
+              type State = typeof acc;
+              type Key = keyof State;
+              if (difference.type === 'CHANGE') {
+                const pathAsString = difference.path.join('.') as Key;
+                const value = difference.value;
+                acc[pathAsString] = value;
+              }
+              return acc;
+            },
+            {} as Partial<typeof currentState>,
+          );
+          return isEmpty(newStateFromDiff) ? null : newStateFromDiff;
+        },
+      });
+
+      const { incrementCountOnly, incrementCount2Only } =
+        storeWithHandleSetAndPartializeAndDiff.getState();
+      // Increment value not included in partialized state
+      act(() => {
+        incrementCount2Only();
+      });
+      // Proxy for determining how many times `handleSet` is called.
+      // handleSet should not be called if partialized state is unchanged
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(
+        storeWithHandleSetAndPartializeAndDiff.temporal.getState().pastStates
+          .length,
+      ).toBe(0);
+      // Advance timer to be within throttle interval
+      vi.advanceTimersByTime(throttleIntervalInMs / 2);
+      act(() => {
+        incrementCountOnly();
+      });
+      // Count is in partialized state, so handleSet should have been called
+      expect(console.error).toHaveBeenCalledTimes(1);
+      // The first instance of a partialized state changing should add to history
+      expect(
+        storeWithHandleSetAndPartializeAndDiff.temporal.getState().pastStates
+          .length,
+      ).toBe(1);
+      vi.useRealTimers();
+    });
+
+    it('should always call throttle function on any partialized or non-partialized state change if no equality or diff fn is provided', () => {
+      global.console.error = vi.fn();
+      vi.useFakeTimers();
+      const throttleIntervalInMs = 1000;
+      const storeWithHandleSetAndPartializeAndDiff = createVanillaStore({
+        handleSet: (handleSet) => {
+          return throttle<typeof handleSet>(
+            (state) => {
+              // used for determining how many times `handleSet` is called
+              console.error('handleSet called');
+              handleSet(state);
+            },
+            throttleIntervalInMs,
+            // Call throttle only on leading edge of timeout
+            { leading: true, trailing: false },
+          );
+        },
+        partialize: (state) => ({
+          count: state.count,
+        }),
+      });
+
+      const { incrementCountOnly, incrementCount2Only } =
+        storeWithHandleSetAndPartializeAndDiff.getState();
+      // Increment value not included in partialized state
+      act(() => {
+        incrementCount2Only();
+      });
+      // Proxy for determining how many times `handleSet` is called.
+      // If no diff nor equality fn is provided, handleSet will be called on all zustand state setting calls.
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(
+        storeWithHandleSetAndPartializeAndDiff.temporal.getState().pastStates
+          .length,
+      ).toBe(1);
+      // Advance timer to be within throttle interval
+      vi.advanceTimersByTime(throttleIntervalInMs / 2);
+      act(() => {
+        incrementCountOnly();
+      });
+      // Throttle should be active, so handleSet shouldn't have been called again
+      expect(console.error).toHaveBeenCalledTimes(1);
+      // The first instance of a partialized state changing should add to history
+      expect(
+        storeWithHandleSetAndPartializeAndDiff.temporal.getState().pastStates
+          .length,
+      ).toBe(1);
+      // Advance timer to be out of throttle interval
+      vi.advanceTimersByTime(throttleIntervalInMs);
+      act(() => {
+        incrementCountOnly();
+      });
+      expect(
+        storeWithHandleSetAndPartializeAndDiff.temporal.getState().pastStates
+          .length,
+      ).toBe(2);
+      vi.useRealTimers();
     });
   });
 


### PR DESCRIPTION
Currently, handleSet gets called even if temporal `state` hasn't changed. One negative result of this is that throttles or debouncers to tracking history can get initialized even if no history-tracked state changes. This can result in unexpected behavior, such as the first instance of a history tracked state changing not getting registered in history, so long as it was preceded by a non-history tracked state changing. 

This PR implements a change so that handleState is only called if `pastState` and `currentState` are not equal.

I'd appreciate some review and feedback, as I am new to this repo and want to make sure that I'm handling all edge cases correctly.

This PR has been tested locally against code like in this Sandbox:
https://codesandbox.io/p/sandbox/zundo-untrackedvalue-change-initiating-throttle-issue-wq9cm8?file=%2Fsrc%2FApp.tsx%3A58%2C11

Here is a gif of this fix working:
![zundo](https://github.com/charkour/zundo/assets/6432833/d6e98ace-1db5-4330-b0ef-28d83a06acd2)
