### PR TITLE
Give users more flexibility in writing handleSet fn (alternative solution to PR #141)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ export const temporal = (<TState>(
       setState(...args);
       const currentState = options?.partialize?.(get()) || get();
       if (userHandleSet) {
-        userHandleSet(internalHandleSet, pastState, currentState);
+        userHandleSet(pastState, currentState);
       } else {
         internalHandleSet(pastState);
       }
@@ -82,7 +82,7 @@ export const temporal = (<TState>(
         set(...args);
         const currentState = options?.partialize?.(get()) || get();
         if (userHandleSet) {
-          userHandleSet(internalHandleSet, pastState, currentState);
+          userHandleSet(pastState, currentState);
         } else {
           internalHandleSet(pastState);
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,8 +33,7 @@ export interface ZundoOptions<TState, PartialTState = TState> {
   handleSet?: (
     handleSet: StoreApi<TState>['setState'],
   ) => (
-    handleSet?: StoreApi<TState>['setState'],
-    pastState?: Partial<PartialTState>,
+    pastState: Partial<PartialTState>,
     currentState?: Partial<PartialTState>,
   ) => void;
   pastStates?: Partial<PartialTState>[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,11 @@ export interface ZundoOptions<TState, PartialTState = TState> {
   onSave?: onSave<TState>;
   handleSet?: (
     handleSet: StoreApi<TState>['setState'],
-  ) => StoreApi<TState>['setState'];
+  ) => (
+    handleSet?: StoreApi<TState>['setState'],
+    pastState?: Partial<PartialTState>,
+    currentState?: Partial<PartialTState>,
+  ) => void;
   pastStates?: Partial<PartialTState>[];
   futureStates?: Partial<PartialTState>[];
   wrapTemporal?: (

--- a/tests/__tests__/options.test.ts
+++ b/tests/__tests__/options.test.ts
@@ -635,7 +635,7 @@ describe('Middleware options', () => {
       vi.useFakeTimers();
       const storeWithHandleSet = createVanillaStore({
         handleSet: (handleSet) => {
-          return throttle<typeof handleSet>((state) => {
+          return throttle((state) => {
             console.error('handleSet called');
             handleSet(state);
           }, 1000);


### PR DESCRIPTION
This is an alternative solution to addressing the issues fixed in https://github.com/charkour/zundo/pull/141

In this solution, rather than changing the conditions under which `handleSet` is called like in the other [PR](https://github.com/charkour/zundo/pull/141), users instead can write a `handleSet` fn that returns a fn that, in addition to receiving `pastState` as before, now also receives `currentState`. 

This allows users to return a function that can, based on their own logic around `pastState` and `currentState`, determine when to run `handleSet`.

This allows users to write a handleSet function like:

```typescript

 handleSet: (handleSet) => {
          const throttleFn = throttle((state) => {
              handleSet(state);
            }, 1000);

         // return a function that will run a throttle fn that runs handleSet, but only if state has changed according to
         // user defined logic
          return (
            pastState: Partial<MyState>,
            currentState?: Partial<MyState>,
          ) => {
            const hasStateChanged =
              diff(pastState, currentState ?? {}).length > 0;
            if (hasStateChanged) {
              throttleFn(pastState);
            }
          };
        },

```
while remaining compatible and non-breaking with existing `handleSet` functions written like:

```typescript

 handleSet: (handleSet) => {
          return throttle((pastState) => {
            handleSet(pastState);
          }, 1000);
        },

```

This solution has been tested locally, and 1 relevant test has been added demonstrating a handleSet fn that uses `currentState` to conditionally run the throttle fn that runs `handleSet`
