### PR TITLE
add support for both esm and cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,19 @@
   "license": "MIT",
   "author": "Charles Kornoelje",
   "type": "module",
-  "main": "dist/index.js",
-  "typings": "dist/index.d.ts",
+  "exports": {
+    "import": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "require": {
+      "types": "./dist/index.d.cts",
+      "default": "./dist/index.cjs"
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist",
     "package.json"


### PR DESCRIPTION
#143

In v2.0.1, I tried to make a change to support ESM and CJS, but misconfigured the package.json so only ESM was supported. 