### PR TITLE
handleSet refactor option 3

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,19 +74,19 @@ export const temporal = (<TState>(
         set(...args);
         const currentState = options?.partialize?.(get()) || get();
         const deltaState = options?.diff?.(pastState, currentState);
-        // Don't call handleSet if state hasn't changed
-          if (
-              !(
-              // If the user has provided an equality function, use it
-              (
-                  options?.equality?.(pastState, currentState) ||
-                  // If the user has provided a diff function but nothing has been changed, function returns null
-                  deltaState === null
-              )
+        // Don't call handleSet if state hasn't changed, as determined by equality or diff fn
+        if (
+          !(
+            // If the user has provided an equality function, use it
+            (
+              options?.equality?.(pastState, currentState) ||
+              // If the user has provided a diff function but nothing has been changed, function returns null
+              deltaState === null
+            )
           )
-          ) {
-              curriedHandleSet(pastState);
-          }
+        ) {
+          curriedHandleSet(pastState);
+        }
       },
       get,
       store,

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,21 @@ export const temporal = (<TState>(
         // The order of the get() and set() calls is important here.
         const pastState = options?.partialize?.(get()) || get();
         set(...args);
-        curriedHandleSet(pastState);
+        const currentState = options?.partialize?.(get()) || get();
+        const deltaState = options?.diff?.(pastState, currentState);
+        // Don't call handleSet if state hasn't changed
+          if (
+              !(
+              // If the user has provided an equality function, use it
+              (
+                  options?.equality?.(pastState, currentState) ||
+                  // If the user has provided a diff function but nothing has been changed, function returns null
+                  deltaState === null
+              )
+          )
+          ) {
+              curriedHandleSet(pastState);
+          }
       },
       get,
       store,

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,10 +50,36 @@ export const temporal = (<TState>(
         temporalStateCreator(set, get, options),
     );
 
-    const curriedHandleSet =
-      options?.handleSet?.(
-        (store.temporal.getState() as _TemporalState<TState>)._handleSet,
-      ) || (store.temporal.getState() as _TemporalState<TState>)._handleSet;
+    const userHandleSet = options?.handleSet?.(
+      (store.temporal.getState() as _TemporalState<TState>)
+        ._handleSet as StoreApi<TState>['setState'],
+    );
+
+    const internalHandleSet = (
+      store.temporal.getState() as _TemporalState<TState>
+    )._handleSet;
+
+    const curriedHandleSet = userHandleSet || internalHandleSet;
+
+    const temporalHandleSet = (
+      pastState: TState,
+      currentState: TState,
+      deltaState?: Partial<TState> | null,
+    ) => {
+      // Don't call handleSet if state hasn't changed, as determined by diff fn or equality fn
+      if (
+        !(
+          // If the user has provided a diff function but nothing has been changed, deltaState will be null
+          (
+            deltaState === null ||
+            // If the user has provided an equality function, use it
+            options?.equality?.(pastState, currentState)
+          )
+        )
+      ) {
+        curriedHandleSet(pastState, currentState, deltaState);
+      }
+    };
 
     const setState = store.setState;
     // Modify the setState function to call the userlandSet function
@@ -62,7 +88,9 @@ export const temporal = (<TState>(
       // The order of the get() and set() calls is important here.
       const pastState = options?.partialize?.(get()) || get();
       setState(...args);
-      curriedHandleSet(pastState);
+      const currentState = options?.partialize?.(get()) || get();
+      const deltaState = options?.diff?.(pastState, currentState);
+      temporalHandleSet(pastState, currentState, deltaState);
     };
 
     return config(
@@ -74,19 +102,7 @@ export const temporal = (<TState>(
         set(...args);
         const currentState = options?.partialize?.(get()) || get();
         const deltaState = options?.diff?.(pastState, currentState);
-        // Don't call handleSet if state hasn't changed, as determined by equality or diff fn
-        if (
-          !(
-            // If the user has provided an equality function, use it
-            (
-              options?.equality?.(pastState, currentState) ||
-              // If the user has provided a diff function but nothing has been changed, function returns null
-              deltaState === null
-            )
-          )
-        ) {
-          curriedHandleSet(pastState);
-        }
+        temporalHandleSet(pastState, currentState, deltaState);
       },
       get,
       store,

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,11 +61,9 @@ export const temporal = (<TState>(
 
     const curriedHandleSet = userHandleSet || internalHandleSet;
 
-    const temporalHandleSet = (
-      pastState: TState,
-      currentState: TState,
-      deltaState?: Partial<TState> | null,
-    ) => {
+    const temporalHandleSet = (pastState: TState) => {
+      const currentState = options?.partialize?.(get()) || get();
+      const deltaState = options?.diff?.(pastState, currentState);
       // Don't call handleSet if state hasn't changed, as determined by diff fn or equality fn
       if (
         !(
@@ -88,9 +86,7 @@ export const temporal = (<TState>(
       // The order of the get() and set() calls is important here.
       const pastState = options?.partialize?.(get()) || get();
       setState(...args);
-      const currentState = options?.partialize?.(get()) || get();
-      const deltaState = options?.diff?.(pastState, currentState);
-      temporalHandleSet(pastState, currentState, deltaState);
+      temporalHandleSet(pastState);
     };
 
     return config(
@@ -100,9 +96,7 @@ export const temporal = (<TState>(
         // The order of the get() and set() calls is important here.
         const pastState = options?.partialize?.(get()) || get();
         set(...args);
-        const currentState = options?.partialize?.(get()) || get();
-        const deltaState = options?.diff?.(pastState, currentState);
-        temporalHandleSet(pastState, currentState, deltaState);
+        temporalHandleSet(pastState);
       },
       get,
       store,

--- a/src/temporal.ts
+++ b/src/temporal.ts
@@ -62,27 +62,17 @@ export const temporalStateCreator = <TState>(
         if (get().isTracking) {
           const currentState = options?.partialize?.(userGet()) || userGet();
           const deltaState = options?.diff?.(pastState, currentState);
-          if (
-            !(
-              // If the user has provided an equality function, use it
-              (
-                options?.equality?.(pastState, currentState) ||
-                // If the user has provided a diff function but nothing has been changed, function returns null
-                deltaState === null
-              )
-            )
-          ) {
-            // This naively assumes that only one new state can be added at a time
-            if (options?.limit && get().pastStates.length >= options?.limit) {
-              get().pastStates.shift();
-            }
 
-            get()._onSave?.(pastState, currentState);
-            set({
-              pastStates: get().pastStates.concat(deltaState || pastState),
-              futureStates: [],
-            });
+          // This naively assumes that only one new state can be added at a time
+          if (options?.limit && get().pastStates.length >= options?.limit) {
+            get().pastStates.shift();
           }
+
+          get()._onSave?.(pastState, currentState);
+          set({
+            pastStates: get().pastStates.concat(deltaState || pastState),
+            futureStates: [],
+          });
         }
       },
     };

--- a/src/temporal.ts
+++ b/src/temporal.ts
@@ -58,11 +58,8 @@ export const temporalStateCreator = <TState>(
       setOnSave: (_onSave) => set({ _onSave }),
       // Internal properties
       _onSave: options?.onSave,
-      _handleSet: (pastState) => {
+      _handleSet: (pastState, currentState, deltaState) => {
         if (get().isTracking) {
-          const currentState = options?.partialize?.(userGet()) || userGet();
-          const deltaState = options?.diff?.(pastState, currentState);
-
           // This naively assumes that only one new state can be added at a time
           if (options?.limit && get().pastStates.length >= options?.limit) {
             get().pastStates.shift();

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,11 @@ export interface _TemporalState<TState> {
 
   setOnSave: (onSave: onSave<TState>) => void;
   _onSave: onSave<TState>;
-  _handleSet: (pastState: TState) => void;
+  _handleSet: (
+    pastState: TState,
+    currentState: TState,
+    deltaState?: Partial<TState> | null,
+  ) => void;
 }
 
 export interface ZundoOptions<TState, PartialTState = TState> {
@@ -32,7 +36,11 @@ export interface ZundoOptions<TState, PartialTState = TState> {
   onSave?: onSave<TState>;
   handleSet?: (
     handleSet: StoreApi<TState>['setState'],
-  ) => StoreApi<TState>['setState'];
+  ) => (
+    pastState: PartialTState,
+    currentState: PartialTState,
+    deltaState?: Partial<PartialTState> | null,
+  ) => void;
   pastStates?: Partial<PartialTState>[];
   futureStates?: Partial<PartialTState>[];
   wrapTemporal?: (

--- a/tests/__tests__/options.test.ts
+++ b/tests/__tests__/options.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
 vi.mock('zustand');
 import { temporal } from '../../src/index';
 import { createStore, type StoreApi } from 'zustand';
@@ -29,7 +30,8 @@ interface MyState {
   boolean1: boolean;
   boolean2: boolean;
   increment: () => void;
-  incrementOnly2: () => void;
+  incrementCountOnly: () => void;
+  incrementCount2Only: () => void;
   decrement: () => void;
   doNothing: () => void;
 }
@@ -56,7 +58,9 @@ const createVanillaStore = (
             count: state.count - 1,
             count2: state.count2 - 1,
           })),
-        incrementOnly2: () => set((state) => ({ count2: state.count2 + 1 })),
+        incrementCountOnly: () => set((state) => ({ count: state.count + 1 })),
+        incrementCount2Only: () =>
+          set((state) => ({ count2: state.count2 + 1 })),
         doNothing: () => set((state) => ({ ...state })),
       };
     }, options),
@@ -95,7 +99,8 @@ describe('Middleware options', () => {
         increment: expect.any(Function),
         decrement: expect.any(Function),
         doNothing: expect.any(Function),
-        incrementOnly2: expect.any(Function),
+        incrementCountOnly: expect.any(Function),
+        incrementCount2Only: expect.any(Function),
         myString: 'hello',
         string2: 'world',
         boolean1: true,
@@ -107,7 +112,8 @@ describe('Middleware options', () => {
         increment: expect.any(Function),
         decrement: expect.any(Function),
         doNothing: expect.any(Function),
-        incrementOnly2: expect.any(Function),
+        incrementCountOnly: expect.any(Function),
+        incrementCount2Only: expect.any(Function),
         myString: 'hello',
         string2: 'world',
         boolean1: true,
@@ -172,7 +178,8 @@ describe('Middleware options', () => {
         increment: expect.any(Function),
         decrement: expect.any(Function),
         doNothing: expect.any(Function),
-        incrementOnly2: expect.any(Function),
+        incrementCountOnly: expect.any(Function),
+        incrementCount2Only: expect.any(Function),
         boolean1: true,
         boolean2: false,
         myString: 'hello',
@@ -193,7 +200,8 @@ describe('Middleware options', () => {
         increment: expect.any(Function),
         decrement: expect.any(Function),
         doNothing: expect.any(Function),
-        incrementOnly2: expect.any(Function),
+        incrementCountOnly: expect.any(Function),
+        incrementCount2Only: expect.any(Function),
         boolean1: true,
         boolean2: false,
         myString: 'hello',
@@ -328,7 +336,8 @@ describe('Middleware options', () => {
           return isEmpty(newStateFromDiff) ? null : newStateFromDiff;
         },
       });
-      const { doNothing, increment, incrementOnly2 } = storeWithDiff.getState();
+      const { doNothing, increment, incrementCount2Only } =
+        storeWithDiff.getState();
       const { undo, redo } = storeWithDiff.temporal.getState();
       act(() => {
         doNothing();
@@ -355,7 +364,7 @@ describe('Middleware options', () => {
       });
       act(() => {
         doNothing();
-        incrementOnly2();
+        incrementCount2Only();
       });
       expect(storeWithDiff.temporal.getState().pastStates.length).toBe(3);
       expect(storeWithDiff.temporal.getState().pastStates[2]).toEqual({
@@ -367,7 +376,7 @@ describe('Middleware options', () => {
       });
       act(() => {
         doNothing();
-        incrementOnly2();
+        incrementCount2Only();
       });
       expect(storeWithDiff.temporal.getState().pastStates.length).toBe(4);
       expect(storeWithDiff.temporal.getState().pastStates[3]).toEqual({
@@ -677,6 +686,7 @@ describe('Middleware options', () => {
       expect(console.error).toHaveBeenCalledTimes(4);
       vi.useRealTimers();
     });
+
     it('should correctly use throttling (wrapTemporal)', () => {
       global.console.error = vi.fn();
       vi.useFakeTimers();
@@ -716,6 +726,184 @@ describe('Middleware options', () => {
         2,
       );
       expect(console.warn).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not call throttle function if partialized state is unchanged according to equality fn', () => {
+      global.console.error = vi.fn();
+      vi.useFakeTimers();
+      const throttleIntervalInMs = 1000;
+      const storeWithHandleSetAndPartializeAndEquality = createVanillaStore({
+        handleSet: (handleSet) => {
+          return throttle<typeof handleSet>(
+            (state) => {
+              // used for determining how many times `handleSet` is called
+              console.error('handleSet called');
+              handleSet(state);
+            },
+            throttleIntervalInMs,
+            // Call throttle only on leading edge of timeout
+            { leading: true, trailing: false },
+          );
+        },
+        partialize: (state) => ({
+          count: state.count,
+        }),
+        equality: (pastState, currentState) =>
+          diff(pastState, currentState).length === 0,
+      });
+
+      const { incrementCountOnly, incrementCount2Only } =
+        storeWithHandleSetAndPartializeAndEquality.getState();
+      // Increment value not included in partialized state
+      act(() => {
+        incrementCount2Only();
+      });
+      // Proxy for determining how many times `handleSet` is called.
+      // handleSet should not be called if partialized state is unchanged
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(
+        storeWithHandleSetAndPartializeAndEquality.temporal.getState()
+          .pastStates.length,
+      ).toBe(0);
+      // Advance timer to be within throttle interval
+      vi.advanceTimersByTime(throttleIntervalInMs / 2);
+      act(() => {
+        incrementCountOnly();
+      });
+      // Count is in partialized state, so handleSet should have been called
+      expect(console.error).toHaveBeenCalledTimes(1);
+      // The first instance of a partialized state changing should add to history
+      expect(
+        storeWithHandleSetAndPartializeAndEquality.temporal.getState()
+          .pastStates.length,
+      ).toBe(1);
+      vi.useRealTimers();
+    });
+
+    it('should not call throttle function if partialized state is unchanged according to diff fn', () => {
+      global.console.error = vi.fn();
+      vi.useFakeTimers();
+      const throttleIntervalInMs = 1000;
+      const storeWithHandleSetAndPartializeAndDiff = createVanillaStore({
+        handleSet: (handleSet) => {
+          return throttle<typeof handleSet>(
+            (state) => {
+              // used for determining how many times `handleSet` is called
+              console.error('handleSet called');
+              handleSet(state);
+            },
+            throttleIntervalInMs,
+            // Call throttle only on leading edge of timeout
+            { leading: true, trailing: false },
+          );
+        },
+        partialize: (state) => ({
+          count: state.count,
+        }),
+        diff: (pastState, currentState) => {
+          const myDiff = diff(currentState, pastState);
+          const newStateFromDiff = myDiff.reduce(
+            (acc, difference) => {
+              type State = typeof acc;
+              type Key = keyof State;
+              if (difference.type === 'CHANGE') {
+                const pathAsString = difference.path.join('.') as Key;
+                const value = difference.value;
+                acc[pathAsString] = value;
+              }
+              return acc;
+            },
+            {} as Partial<typeof currentState>,
+          );
+          return isEmpty(newStateFromDiff) ? null : newStateFromDiff;
+        },
+      });
+
+      const { incrementCountOnly, incrementCount2Only } =
+        storeWithHandleSetAndPartializeAndDiff.getState();
+      // Increment value not included in partialized state
+      act(() => {
+        incrementCount2Only();
+      });
+      // Proxy for determining how many times `handleSet` is called.
+      // handleSet should not be called if partialized state is unchanged
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(
+        storeWithHandleSetAndPartializeAndDiff.temporal.getState().pastStates
+          .length,
+      ).toBe(0);
+      // Advance timer to be within throttle interval
+      vi.advanceTimersByTime(throttleIntervalInMs / 2);
+      act(() => {
+        incrementCountOnly();
+      });
+      // Count is in partialized state, so handleSet should have been called
+      expect(console.error).toHaveBeenCalledTimes(1);
+      // The first instance of a partialized state changing should add to history
+      expect(
+        storeWithHandleSetAndPartializeAndDiff.temporal.getState().pastStates
+          .length,
+      ).toBe(1);
+      vi.useRealTimers();
+    });
+
+    it('should always call throttle function on any partialized or non-partialized state change if no equality or diff fn is provided', () => {
+      global.console.error = vi.fn();
+      vi.useFakeTimers();
+      const throttleIntervalInMs = 1000;
+      const storeWithHandleSetAndPartializeAndDiff = createVanillaStore({
+        handleSet: (handleSet) => {
+          return throttle<typeof handleSet>(
+            (state) => {
+              // used for determining how many times `handleSet` is called
+              console.error('handleSet called');
+              handleSet(state);
+            },
+            throttleIntervalInMs,
+            // Call throttle only on leading edge of timeout
+            { leading: true, trailing: false },
+          );
+        },
+        partialize: (state) => ({
+          count: state.count,
+        }),
+      });
+
+      const { incrementCountOnly, incrementCount2Only } =
+        storeWithHandleSetAndPartializeAndDiff.getState();
+      // Increment value not included in partialized state
+      act(() => {
+        incrementCount2Only();
+      });
+      // Proxy for determining how many times `handleSet` is called.
+      // If no diff nor equality fn is provided, handleSet will be called on all zustand state setting calls.
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(
+        storeWithHandleSetAndPartializeAndDiff.temporal.getState().pastStates
+          .length,
+      ).toBe(1);
+      // Advance timer to be within throttle interval
+      vi.advanceTimersByTime(throttleIntervalInMs / 2);
+      act(() => {
+        incrementCountOnly();
+      });
+      // Throttle should be active, so handleSet shouldn't have been called again
+      expect(console.error).toHaveBeenCalledTimes(1);
+      // The first instance of a partialized state changing should add to history
+      expect(
+        storeWithHandleSetAndPartializeAndDiff.temporal.getState().pastStates
+          .length,
+      ).toBe(1);
+      // Advance timer to be out of throttle interval
+      vi.advanceTimersByTime(throttleIntervalInMs);
+      act(() => {
+        incrementCountOnly();
+      });
+      expect(
+        storeWithHandleSetAndPartializeAndDiff.temporal.getState().pastStates
+          .length,
+      ).toBe(2);
+      vi.useRealTimers();
     });
   });
 


### PR DESCRIPTION
This PR is to explore the solution space around ideas around this [issue](https://github.com/charkour/zundo/issues/139), specifically based on this [comment](https://github.com/charkour/zundo/pull/141#discussion_r1435720419)

TL;DR This PR and [PR 141](https://github.com/charkour/zundo/pull/141) look very similar now at first glance. To see the primary difference, note how `curriedHandleSet` takes different numbers of parameters in the two PRs.

Background: 
In [PR 141](https://github.com/charkour/zundo/pull/141/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R72), there are zero changes to the ZundoOptions API. However, in bringing the state change check in prior to calling `curriedHandleSet`, we have the minorish drawback of having to calculate `currentState` and `deltaState` BOTH 1) to calculate the check for calling `curriedHandleSet` and 2) within `curriedHandleSet`. 

An idea was then -- instead of calculating those values twice, maybe we just calculate those things once and just pass them to `curriedHandleSet`. So that's what we do in this PR.

While we resolve the redundant calculation issue, the drawback though is that we cannot both let `curriedHandleSet` accept more parameters and _not_ simultaneously have absolutely zero changes to the API. Like PR 142, options.handleSet now returns a function that, in addition to `pastState` as before, now technically also receives the values of `currentState` and `deltaState`. So like in [PR 142](https://github.com/charkour/zundo/pull/142), the minor change to the API is that users now also have access to these values and can use them in logic (although in this PR they no longer need to to resolve the throttling/untrackedValue issues themselves with additional logic, as that is now, like in PR 141, always resolved by the conditional check if equality or diff functions exist.

All that being said, I believe this change (this PR) is non breaking and all current compositions of `handleSet` will continue to work as expected (the same is true of the other PRs as well). All tests pass, and this was tested locally with previous compositions of `handleSet`.