### PR TITLE
[v3] remove _handleSet from _TemporalState

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,11 +50,39 @@ export const temporal = (<TState>(
         temporalStateCreator(set, get, options),
     );
 
+    const handleSet = (
+      pastState: TState,
+      // `replace` will likely be deprecated and removed in the future
+      replace: boolean | undefined,
+      currentState: TState,
+      deltaState?: Partial<TState>,
+    ) => {
+      if (store.temporal.getState().isTracking) {
+        // This naively assumes that only one new state can be added at a time
+        if (
+          options?.limit &&
+          store.temporal.getState().pastStates.length >= options?.limit
+        ) {
+          store.temporal.getState().pastStates.shift();
+        }
+
+        (store.temporal.getState() as _TemporalState<TState>)._onSave?.(
+          pastState,
+          currentState,
+        );
+        store.temporal.setState({
+          ...store.temporal.getState(),
+          pastStates: store.temporal
+            .getState()
+            .pastStates.concat(deltaState || pastState),
+          futureStates: [],
+        });
+      }
+    };
+
     const curriedHandleSet =
-      options?.handleSet?.(
-        (store.temporal.getState() as _TemporalState<TState>)
-          ._handleSet as StoreApi<TState>['setState'],
-      ) || (store.temporal.getState() as _TemporalState<TState>)._handleSet;
+      options?.handleSet?.(handleSet as StoreApi<TState>['setState']) ||
+      handleSet;
 
     const temporalHandleSet = (pastState: TState) => {
       if (!store.temporal.getState().isTracking) return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,6 @@ export const temporal = (<TState>(
           currentState,
         );
         store.temporal.setState({
-          ...store.temporal.getState(),
           pastStates: store.temporal
             .getState()
             .pastStates.concat(deltaState || pastState),

--- a/src/temporal.ts
+++ b/src/temporal.ts
@@ -58,18 +58,6 @@ export const temporalStateCreator = <TState>(
       setOnSave: (_onSave) => set({ _onSave }),
       // Internal properties
       _onSave: options?.onSave,
-      _handleSet: (pastState, replace, currentState, deltaState) => {
-        // This naively assumes that only one new state can be added at a time
-        if (options?.limit && get().pastStates.length >= options?.limit) {
-          get().pastStates.shift();
-        }
-
-        get()._onSave?.(pastState, currentState);
-        set({
-          pastStates: get().pastStates.concat(deltaState || pastState),
-          futureStates: [],
-        });
-      },
     };
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,13 +18,6 @@ export interface _TemporalState<TState> {
 
   setOnSave: (onSave: onSave<TState>) => void;
   _onSave: onSave<TState>;
-  _handleSet: (
-    pastState: TState,
-    // `replace` will likely be deprecated and removed in the future
-    replace: Parameters<StoreApi<TState>['setState']>[1],
-    currentState: TState,
-    deltaState?: Partial<TState> | null,
-  ) => void;
 }
 
 export interface ZundoOptions<TState, PartialTState = TState> {
@@ -60,7 +53,4 @@ export interface ZundoOptions<TState, PartialTState = TState> {
 
 export type Write<T, U> = Omit<T, keyof U> & U;
 
-export type TemporalState<TState> = Omit<
-  _TemporalState<TState>,
-  '_onSave' | '_handleSet'
->;
+export type TemporalState<TState> = Omit<_TemporalState<TState>, '_onSave'>;

--- a/tests/__tests__/options.test.ts
+++ b/tests/__tests__/options.test.ts
@@ -607,6 +607,7 @@ describe('Middleware options', () => {
               console.info('handleSet called');
               _set(partial, replace);
             };
+            store.setState = set;
             return config(set, get, store);
           };
         },
@@ -700,6 +701,7 @@ describe('Middleware options', () => {
               },
               1000,
             );
+            store.setState = set;
             return config(set, get, store);
           };
         },

--- a/tests/__tests__/options.test.ts
+++ b/tests/__tests__/options.test.ts
@@ -640,6 +640,28 @@ describe('Middleware options', () => {
       expect(console.info).toHaveBeenCalledTimes(3);
     });
 
+    it('should not call function if `store.setState` is not assigned to `set` (wrapTemporal)', () => {
+      global.console.info = vi.fn();
+      const storeWithHandleSet = createVanillaStore({
+        wrapTemporal: (config) => {
+          return (_set, get, store) => {
+            const set: typeof _set = (partial, replace) => {
+              console.info('handleSet called');
+              _set(partial, replace);
+            };
+            // intentionally commented out
+            // store.setState = set;
+            return config(set, get, store);
+          };
+        },
+      });
+      const { increment } = storeWithHandleSet.getState();
+      act(() => {
+        increment();
+      });
+      expect(console.info).toHaveBeenCalledTimes(0);
+    });
+
     it('should correctly use throttling', () => {
       global.console.error = vi.fn();
       vi.useFakeTimers();

--- a/tests/__tests__/options.test.ts
+++ b/tests/__tests__/options.test.ts
@@ -942,9 +942,7 @@ describe('Middleware options', () => {
 
   describe('secret internals', () => {
     it('should have a secret internal state', () => {
-      const { _handleSet, _onSave } =
-        store.temporal.getState() as _TemporalState<MyState>;
-      expect(_handleSet).toBeInstanceOf(Function);
+      const { _onSave } = store.temporal.getState() as _TemporalState<MyState>;
       expect(_onSave).toBe(undefined);
     });
     describe('onSave', () => {
@@ -1012,19 +1010,6 @@ describe('Middleware options', () => {
         expect(console.dir).toHaveBeenCalledTimes(1);
         expect(console.trace).toHaveBeenCalledTimes(1);
       });
-    });
-
-    describe('handleUserSet', () => {
-      it('should update the temporal store with the pastState when called', () => {
-        const { _handleSet } =
-          store.temporal.getState() as _TemporalState<MyState>;
-        act(() => {
-          _handleSet(store.getState(), undefined, store.getState(), null);
-        });
-        expect(store.temporal.getState().pastStates.length).toBe(1);
-      });
-
-      // TODO: should this check the equality function, limit, and call onSave? These are already tested but indirectly.
     });
   });
 


### PR DESCRIPTION
This PR removes the `_handleSet` internal property of `_TemporalState` in favor of defining `handleSet` within `temporal` (index.ts). 

This is beneficial from a complexity-reducing standpoint: `_handleSet` no longer needs to be a member of the temporal state, and its functionality is easily discoverable and readable within `temporal`.

  This change also allows us to remove the type assertion required for accessing private internal properties of `_TemporalState` when using `getState()`, which returns type `TemporalState`.