### PR TITLE
fix spying on wrong function

### DIFF
--- a/tests/__tests__/options.test.ts
+++ b/tests/__tests__/options.test.ts
@@ -725,7 +725,7 @@ describe('Middleware options', () => {
       expect(storeWithHandleSet.temporal.getState().futureStates.length).toBe(
         2,
       );
-      expect(console.warn).toHaveBeenCalledTimes(2);
+      expect(console.error).toHaveBeenCalledTimes(3);
     });
 
     it('should not call throttle function if partialized state is unchanged according to equality fn', () => {


### PR DESCRIPTION
In the scope of this test, only `console.error` is defined. 

Any time the `temporal` store's setter is called, `console.error` should be called. 