### PR TITLE
update matrix and version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
-        zustand: [latest, 4.2.0, 4.0.0, 5.0.0-alpha.5]
+        node-version: [16.x, 20.x]
+        zustand: [latest, 4.2.0, 4.0.0, 5.0.0-alpha.6]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- Remove middle Node version; assumes that if v16 works and v20 works, any intermediate versions will also work. 
- Use latest zustand v5